### PR TITLE
Name anonymous default exports to support Fast Refresh in NextJS 9.5

### DIFF
--- a/src/isHoverEnabled.native.ts
+++ b/src/isHoverEnabled.native.ts
@@ -1,1 +1,3 @@
-export default () => false;
+const isHoverEnabled = () => false;
+
+export default isHoverEnabled;

--- a/src/isHoverEnabled.ts
+++ b/src/isHoverEnabled.ts
@@ -36,4 +36,6 @@ if (canUseDOM) {
   document.addEventListener('mousemove', enableHover, true);
 }
 
-export default () => isEnabled;
+const isHoverEnabled = () => isEnabled;
+
+export default isHoverEnabled;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1668,17 +1668,6 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
-babel-preset-expo@^8.0.0, babel-preset-expo@~8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-expo/-/babel-preset-expo-8.0.0.tgz#08c042363189f2d871381f0d0dbf9644e9f67aea"
-  integrity sha512-40UCIE4E+9Xx5K+oEidFHML2+j/WE/ikcC7+3ndWx74MtdmRAtnGecboKRiGUK/vMrHzXIcWPP6/SOnE7zQVgQ==
-  dependencies:
-    "@babel/plugin-proposal-decorators" "^7.6.0"
-    "@babel/preset-env" "^7.6.3"
-    babel-plugin-module-resolver "^3.2.0"
-    babel-plugin-react-native-web "^0.11.7"
-    metro-react-native-babel-preset "^0.56.0"
-
 babel-preset-expo@~7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/babel-preset-expo/-/babel-preset-expo-7.0.0.tgz#1d288e0efb17dcea84b0d30ce5f5ab99f781ae4a"
@@ -1691,6 +1680,17 @@ babel-preset-expo@~7.0.0:
     babel-plugin-module-resolver "^3.1.1"
     babel-plugin-react-native-web "^0.11.2"
     metro-react-native-babel-preset "^0.54.1"
+
+babel-preset-expo@~8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-expo/-/babel-preset-expo-8.0.0.tgz#08c042363189f2d871381f0d0dbf9644e9f67aea"
+  integrity sha512-40UCIE4E+9Xx5K+oEidFHML2+j/WE/ikcC7+3ndWx74MtdmRAtnGecboKRiGUK/vMrHzXIcWPP6/SOnE7zQVgQ==
+  dependencies:
+    "@babel/plugin-proposal-decorators" "^7.6.0"
+    "@babel/preset-env" "^7.6.3"
+    babel-plugin-module-resolver "^3.2.0"
+    babel-plugin-react-native-web "^0.11.7"
+    metro-react-native-babel-preset "^0.56.0"
 
 babel-preset-fbjs@^3.1.2, babel-preset-fbjs@^3.2.0:
   version "3.3.0"


### PR DESCRIPTION
## Why

NextJS 9.5 brings up a new warning when using this package related to fast refresh:

```
warn  - ./node_modules/react-native-web-hooks/build/isHoverEnabled.js
Anonymous arrow functions cause Fast Refresh to not preserve local component state.
Please add a name to your function, for example:

Before
export default () => <div />;

After
const Named = () => <div />;
export default Named;
```

## How 

- assigned default exports of `isHoverEnabled[.native].ts` to `isHoverEnabled` and exported that

## Thanks for your time :)

![smile_12](https://user-images.githubusercontent.com/12488826/89464791-e12ff600-d725-11ea-92c8-6bcdc0606025.gif)
